### PR TITLE
Fix update and delete event

### DIFF
--- a/src/android/nl/xservices/plugins/Calendar.java
+++ b/src/android/nl/xservices/plugins/Calendar.java
@@ -629,18 +629,18 @@ public class Calendar extends CordovaPlugin {
               argObject.getLong("newStartTime"),
               argObject.getLong("newEndTime"),
               getPossibleNullString("id", argOptionsObject),
-              argNewOptionsObject.optLong("newFirstReminderMinutes", -1),
-              argNewOptionsObject.optLong("newSecondReminderMinutes", -1),
-              getPossibleNullString("newRecurrence", argNewOptionsObject),
-              argNewOptionsObject.optInt("newRecurrenceInterval", -1),
-              getPossibleNullString("newRecurrenceWeekstart", argNewOptionsObject),
-              getPossibleNullString("newRecurrenceByDay", argNewOptionsObject),
-              getPossibleNullString("newRecurrenceByMonthDay", argNewOptionsObject),
-              argNewOptionsObject.optLong("newRecurrenceEndTime", -1),
-              argNewOptionsObject.optLong("newRecurrenceCount", -1),
-              getPossibleNullString("newAllday", argNewOptionsObject),
-              argNewOptionsObject.optInt("newCalendarId", -1),
-              getPossibleNullString("newUrl", argNewOptionsObject));
+              argNewOptionsObject.optLong("firstReminderMinutes", -1),
+              argNewOptionsObject.optLong("secondReminderMinutes", -1),
+              getPossibleNullString("recurrence", argNewOptionsObject),
+              argNewOptionsObject.optInt("recurrenceInterval", -1),
+              getPossibleNullString("recurrenceWeekstart", argNewOptionsObject),
+              getPossibleNullString("recurrenceByDay", argNewOptionsObject),
+              getPossibleNullString("recurrenceByMonthDay", argNewOptionsObject),
+              argNewOptionsObject.optLong("recurrenceEndTime", -1),
+              argNewOptionsObject.optLong("recurrenceCount", -1),
+              getPossibleNullString("allday", argNewOptionsObject),
+              argNewOptionsObject.optInt("calendarId", -1),
+              getPossibleNullString("url", argNewOptionsObject));
             if (updatedRows > 0) {
               callback.success(updatedRows);
             } else {

--- a/src/ios/Calendar.m
+++ b/src/ios/Calendar.m
@@ -190,6 +190,7 @@
     CDVPluginResult *pluginResult = nil;
     if (theEvent != nil) {
       NSDictionary* newCalOptions = [options objectForKey:@"newOptions"];
+      BOOL thisAndFollowingEvents = [[newCalOptions objectForKey:@"thisAndFollowingEvents"] boolValue];
       NSString* newCalendarName = [newCalOptions objectForKey:@"calendarName"];
       if (newCalendarName != (id)[NSNull null]) {
         theEvent.calendar = [self findEKCalendar:calendarName];
@@ -276,7 +277,8 @@
 
       // Now save the new details back to the store
       NSError *error = nil;
-      [self.eventStore saveEvent:theEvent span:EKSpanThisEvent error:&error];
+      [self.eventStore saveEvent:theEvent span:thisAndFollowingEvents ? EKSpanFutureEvents
+ : EKSpanThisEvent error:&error];
 
 
       // Check error code + return result
@@ -889,6 +891,7 @@
 - (void) deleteEventById:(CDVInvokedUrlCommand*)command {
   NSDictionary* options = [command.arguments objectAtIndex:0];
   NSString* ciid = [options objectForKey:@"id"];
+  BOOL thisAndFollowingEvents = [[options objectForKey:@"thisAndFollowingEvents"] boolValue];
   NSNumber* fromTime = [options objectForKey:@"fromTime"];
 
   [self.commandDelegate runInBackground: ^{
@@ -921,7 +924,8 @@
 
       // Delete
       NSError *error = nil;
-      [eventStore removeEvent:instance span:EKSpanFutureEvents error:&error];
+      [eventStore removeEvent:instance span:thisAndFollowingEvents ? EKSpanFutureEvents
+ : EKSpanThisEvent error:&error];
       if (error != nil) {
         // Fail
         [self.commandDelegate

--- a/src/ios/Calendar.m
+++ b/src/ios/Calendar.m
@@ -239,9 +239,26 @@
       NSNumber* intervalAmount = [newCalOptions objectForKey:@"recurrenceInterval"];
 
       if (recurrence != (id)[NSNull null]) {
-        EKRecurrenceRule *rule = [[EKRecurrenceRule alloc] initRecurrenceWithFrequency: [self toEKRecurrenceFrequency:recurrence]
-                                                                              interval: intervalAmount.integerValue
-                                                                                   end: nil];
+        NSMutableArray *daysOfTheWeekArray = [NSMutableArray array];
+
+        NSArray* daysOfTheWeek = [newCalOptions objectForKey:@"daysOfTheWeek"];
+        if (daysOfTheWeek != nil) {
+
+          for (NSString* dayOfTheWeek in daysOfTheWeek) {
+            EKRecurrenceDayOfWeek *weekDay = [[EKRecurrenceDayOfWeek alloc] initWithDayOfTheWeek:[self toEKWeekday:dayOfTheWeek] weekNumber:0];
+            [daysOfTheWeekArray addObject:weekDay];
+          }
+
+        }
+      EKRecurrenceRule *rule = [[EKRecurrenceRule alloc] initRecurrenceWithFrequency: [self toEKRecurrenceFrequency:recurrence]
+                                                                            interval: intervalAmount.integerValue
+                                                                       daysOfTheWeek: daysOfTheWeekArray
+                                                                      daysOfTheMonth: nil
+                                                                     monthsOfTheYear: nil
+                                                                      weeksOfTheYear: nil
+                                                                       daysOfTheYear: nil
+                                                                        setPositions: nil
+                                                                                 end: nil];
         NSString* recurrenceEndTime = [newCalOptions objectForKey:@"recurrenceEndTime"];
         if (recurrenceEndTime != nil) {
           NSTimeInterval _recurrenceEndTimeInterval = [recurrenceEndTime doubleValue] / 1000; // strip millis
@@ -463,18 +480,18 @@
         if (rule.daysOfTheWeek != nil) {
             NSMutableArray * daysOfTheWeek = [[NSMutableArray alloc] init];
             for (EKRecurrenceDayOfWeek * item in rule.daysOfTheWeek) {
-                
+
                 NSMutableDictionary *dayofweek = [[NSMutableDictionary alloc] init];
-                
+
                 // objectAtIndex starts at 0, but 'item.dayOfTheWeek' starts at 1
                 NSString *valOfDayOfWeek = [[NSArray arrayWithObjects:@"Unknown", @"Sunday", @"Monday", @"Tuesday", @"Wednesday", @"Thursday", @"Friday", @"Saturday", nil] objectAtIndex:item.dayOfTheWeek];
                 [dayofweek setObject:valOfDayOfWeek forKey:@"dayOfTheWeek"];
-                
+
                 NSNumber *valOfWeekNumber = [NSNumber numberWithInteger:item.weekNumber];
                 [dayofweek setObject:valOfWeekNumber forKey:@"weekNumber"];
-                
+
                 [daysOfTheWeek addObject:dayofweek];
-                
+
             }
             [rrule setObject:daysOfTheWeek forKey:@"daysOfTheWeek"];
         }
@@ -494,7 +511,7 @@
             }
             [rrule setObject:daysOfTheYear forKey:@"daysOfTheYear"];
         }
-        
+
         if (rule.weeksOfTheYear != nil) {
             NSMutableArray * weeksOfTheYear = [[NSMutableArray alloc] init];
             for (NSNumber * item in rule.weeksOfTheYear) {
@@ -605,7 +622,7 @@
       pluginResult = [CDVPluginResult resultWithStatus: CDVCommandStatus_OK messageAsArray:eventsDataArray];
 
       [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-  }];  
+  }];
 }
 
 - (void)createEventWithOptions:(CDVInvokedUrlCommand*)command {
@@ -690,7 +707,7 @@
     if (secondReminderMinutes != (id)[NSNull null]) {
       EKAlarm *reminder = [EKAlarm alarmWithRelativeOffset:-1*secondReminderMinutes.intValue*60];
       [myEvent addAlarm:reminder];
-    }     
+    }
 
     if (recurrence != (id)[NSNull null]) {
         NSMutableArray *daysOfTheWeekArray = [NSMutableArray array];
@@ -701,7 +718,7 @@
             EKRecurrenceDayOfWeek *weekDay = [[EKRecurrenceDayOfWeek alloc] initWithDayOfTheWeek:[self toEKWeekday:dayOfTheWeek] weekNumber:0];
             [daysOfTheWeekArray addObject:weekDay];
           }
-          
+
         }
       EKRecurrenceRule *rule = [[EKRecurrenceRule alloc] initRecurrenceWithFrequency: [self toEKRecurrenceFrequency:recurrence]
                                                                             interval: recurrenceIntervalAmount.integerValue
@@ -711,7 +728,7 @@
                                                                       weeksOfTheYear: nil
                                                                        daysOfTheYear: nil
                                                                         setPositions: nil
-                                                                                 end: nil];        
+                                                                                 end: nil];
         if (recurrenceEndTime != nil) {
         NSTimeInterval _recurrenceEndTimeInterval = [recurrenceEndTime doubleValue] / 1000; // strip millis
         NSDate *myRecurrenceEndDate = [NSDate dateWithTimeIntervalSince1970:_recurrenceEndTimeInterval];

--- a/www/Calendar.js
+++ b/www/Calendar.js
@@ -1,3 +1,4 @@
+cordova.define("cordova-plugin-calendar.Calendar", function(require, exports, module) {
 "use strict";
 function Calendar() {
 }
@@ -208,9 +209,10 @@ Calendar.prototype.deleteEventFromNamedCalendar = function (title, location, not
   }])
 };
 
-Calendar.prototype.deleteEventById = function (id, fromDate, successCallback, errorCallback) {
+Calendar.prototype.deleteEventById = function (id, thisAndFollowingEvents, fromDate, successCallback, errorCallback) {
   cordova.exec(successCallback, errorCallback, "Calendar", "deleteEventById", [{
     "id": id,
+    "thisAndFollowingEvents": thisAndFollowingEvents,
     "fromTime": fromDate instanceof Date ? fromDate.getTime() : null
   }]);
 };
@@ -300,3 +302,5 @@ Calendar.install = function () {
 };
 
 cordova.addConstructor(Calendar.install);
+
+});


### PR DESCRIPTION
[use thisAndFollowingEvents for update and delete](https://github.com/Curve-Tomorrow/Calendar-PhoneGap-Plugin/pull/8/commits/639643345a9f2aa865131392bc24cf23a165672a) 
- add to use `thisAndFollowingEvents` for update and delete event on iOS

[use daysOfTheWeek for update recurring event](https://github.com/Curve-Tomorrow/Calendar-PhoneGap-Plugin/pull/8/commits/f361835103556750daadc2ca54a0808d049ce1b3) 
- add to use `daysOfTheWeek` for update recurring event on iOS

[fix newOptions fields for update event](https://github.com/Curve-Tomorrow/Calendar-PhoneGap-Plugin/pull/8/commits/4bb80980335f8fc4a385807a66e7db050764f1d6) 
- fix `newOptions` fields for update event on Android

[add a new parameter to deleteEventById method](https://github.com/Curve-Tomorrow/Calendar-PhoneGap-Plugin/pull/8/commits/bdfbd4fb0d6ec89f5900feb963d7b34beedd1167) 
- add `thisAndFollowingEvents` parameter to `deleteEventById`